### PR TITLE
fix: updates 'refresh_token' and 'refresh_expires_in' to be optional properties on the ITokenResponse

### DIFF
--- a/src/ITokenResponse.ts
+++ b/src/ITokenResponse.ts
@@ -1,8 +1,8 @@
 export default interface ITokenResponse {
   access_token: string;
   expires_in: number;
-  refresh_expires_in: number;
-  refresh_token: string;
+  refresh_expires_in?: number;
+  refresh_token?: string;
   scope: string;
   token_type: string;
 }


### PR DESCRIPTION
> refresh_token
>
>         OPTIONAL.  The refresh token, which can be used to obtain new
>         access tokens using the same authorization grant as described
>         in Section 6.

https://datatracker.ietf.org/doc/html/rfc6749#section-5.1